### PR TITLE
Use election API to record ballots

### DIFF
--- a/src/electionguard/api/electionGuardApi.ts
+++ b/src/electionguard/api/electionGuardApi.ts
@@ -11,8 +11,9 @@ import {
 } from '../models'
 import fetchJSON from './fetchJSON'
 import { KeyMap } from '../models/KeyMap'
+import * as GLOBAL from '../../config/globals'
 
-export const DEFAULT_BALLOT_EXPORT_PATH = '~/election_results/ballots'
+export const DEFAULT_BALLOT_EXPORT_PATH = `.${GLOBAL.PATH_DELIMITER}election_results/ballots`
 export const DEFAULT_BALLOT_EXPORT_PREFIX = 'my_election_ballots'
 export const DEFAULT_TALLY_EXPORT_PATH = '~/election_results/tallies'
 export const DEFAULT_TALLY_EXPORT_PREFIX = 'my_election_tallies'
@@ -39,7 +40,7 @@ const recordBallots = (
   exportPath: string = DEFAULT_BALLOT_EXPORT_PATH,
   exportFileNamePrefix: string = DEFAULT_BALLOT_EXPORT_PREFIX
 ) => {
-  return fetchJSON<RecordBallotsResponse>('/election', {
+  return fetchJSON<RecordBallotsResponse>('/election/RecordBallots', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/src/pages/Tally/BallotRegistrationPage.tsx
+++ b/src/pages/Tally/BallotRegistrationPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 import { RouteComponentProps } from 'react-router-dom'
 import Main, { MainChild } from '../../components/Main'
@@ -35,7 +35,10 @@ const BallotListButton = (
 }
 
 const BallotRegistrationPage = (props: RouteComponentProps) => {
-  const { castIds, spoiledIds, encryptedBallots } = useContext(TallyContext)
+  const [isRecordingBallots, setIsRecordingBallots] = useState(false)
+  const { castIds, spoiledIds, encryptedBallots, recordBallots } = useContext(
+    TallyContext
+  )
   const ready = (): boolean => {
     return (
       castIds.length > 0 && spoiledIds.length > 0 && encryptedBallots.length > 0
@@ -44,6 +47,17 @@ const BallotRegistrationPage = (props: RouteComponentProps) => {
 
   const navigate = (to: string) => {
     props.history.push(to)
+  }
+
+  const recordAndTallyBallots = async () => {
+    setIsRecordingBallots(true)
+    try {
+      await recordBallots()
+      navigate('/tally')
+    } catch (error) {
+      setIsRecordingBallots(false)
+      throw error
+    }
   }
 
   return (
@@ -77,10 +91,10 @@ const BallotRegistrationPage = (props: RouteComponentProps) => {
         <p>
           <LinkButton
             big
-            primary={ready()}
-            disabled={!ready()}
-            to="/tally"
+            primary={ready() && !isRecordingBallots}
+            disabled={!ready() || isRecordingBallots}
             id="next"
+            onPress={recordAndTallyBallots}
           >
             Next
           </LinkButton>


### PR DESCRIPTION
Prior to this change, ballots were stubbed. This change wires up the
integration with the election API so that they can be recorded for
tallying.

Note: the export path has been altered. It seems the API does not
support the use of '~' as the home shortcut. It has been changed to the
globals path delimiter to make supporting different OSes easier.

Closes: #23 

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.


### Description
Please describe your pull request.

💔Thank you!