### PR TITLE
#54 enable back button on ballot registration page

### DIFF
--- a/src/pages/Tally/BallotRegistrationPage.tsx
+++ b/src/pages/Tally/BallotRegistrationPage.tsx
@@ -11,6 +11,7 @@ import StatusButton, { StatusButtonGrid } from '../../components/StatusButton'
 import { CompletionStatus } from '../../config/types'
 import { CHECK_ICON, WARNING_ICON } from '../../config/globals'
 import TallyContext from '../../contexts/tallyContext'
+import { EncryptedBallot } from '../../electionguard/models/EncryptedBallot'
 
 const Header = styled.div`
   margin: 0 auto;
@@ -49,7 +50,17 @@ const BallotRegistrationPage = (props: RouteComponentProps) => {
     spoiledIds,
     encryptedBallots,
     recordAndTallyBallots,
+    setEncryptedBallots,
+    setCastIds,
+    setSpoiledIds,
   } = useContext(TallyContext)
+
+  const back = (to: string) => {
+    setEncryptedBallots((undefined as unknown) as EncryptedBallot[])
+    setCastIds((undefined as unknown) as string[])
+    setSpoiledIds((undefined as unknown) as string[])
+    props.history.push(to)
+  }
 
   const disable = (): boolean => {
     return (
@@ -133,7 +144,7 @@ const BallotRegistrationPage = (props: RouteComponentProps) => {
           </LinkButton>
         </p>
         <p>
-          <LinkButton disabled small to="/trustees" id="back">
+          <LinkButton small onPress={() => back('/trustees')} id="back">
             Back
           </LinkButton>
         </p>


### PR DESCRIPTION
### Issue

Fixes #54 

### Description
Enable the back button and reset any loaded state data

### Testing
1. Tally Votes
2. Announce trustees
3. load a ballot file
4. press back
5. press next to go back to ballot registration

Expected: all loaded files are missing (with a red background)

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.

💔Thank you!