### PR TITLE
Feature/ballot reg sanitize

### DIFF
--- a/src/electionguard/api/fetchJSON.ts
+++ b/src/electionguard/api/fetchJSON.ts
@@ -11,6 +11,7 @@ export async function fetchJSON<T>(
   })
 
   if (!response.ok) {
+    // eslint-disable-next-line no-console
     console.error(response)
     throw new Error('fetch response is not ok')
   }

--- a/src/pages/Tally/BallotRegistrationPage.tsx
+++ b/src/pages/Tally/BallotRegistrationPage.tsx
@@ -11,6 +11,7 @@ import StatusButton, { StatusButtonGrid } from '../../components/StatusButton'
 import { CompletionStatus } from '../../config/types'
 import { CHECK_ICON, WARNING_ICON } from '../../config/globals'
 import TallyContext from '../../contexts/tallyContext'
+import { EncryptedBallot } from '../../electionguard/models/EncryptedBallot'
 
 const Header = styled.div`
   margin: 0 auto;
@@ -49,7 +50,17 @@ const BallotRegistrationPage = (props: RouteComponentProps) => {
     spoiledIds,
     encryptedBallots,
     recordAndTallyBallots,
+    setEncryptedBallots,
+    setCastIds,
+    setSpoiledIds,
   } = useContext(TallyContext)
+
+  const back = (to: string) => {
+    setEncryptedBallots((undefined as unknown) as EncryptedBallot[])
+    setCastIds((undefined as unknown) as string[])
+    setSpoiledIds((undefined as unknown) as string[])
+    props.history.push(to)
+  }
 
   const disable = (): boolean => {
     return (
@@ -133,7 +144,7 @@ const BallotRegistrationPage = (props: RouteComponentProps) => {
           </LinkButton>
         </p>
         <p>
-          <LinkButton disabled small to="/trustees" id="back">
+          <LinkButton small onPress={() => back('/trustees')} id="back">
             Back
           </LinkButton>
         </p>

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,0 +1,21 @@
+export default function distinct<T>(
+  array: T[],
+  byKeySelector: (key: T) => string | number
+): T[] {
+  const distinctElements: T[] = []
+
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0, { length } = array; i < length; i++) {
+    const existingElement = distinctElements.find(
+      o => byKeySelector(o) === byKeySelector(array[i])
+    )
+    if (existingElement !== undefined) {
+      const existingIndex = distinctElements.indexOf(existingElement)
+      distinctElements[existingIndex] = array[i]
+    } else {
+      distinctElements.push(array[i])
+    }
+  }
+
+  return distinctElements
+}


### PR DESCRIPTION
### Issue

Fixes #58 

### Description
If there are duplicate ballot id's, the last one wins.

### Testing
1. Create some encrypted ballots (e.g., 10)
2. modify the file by copying and pasting the last line into the file to simulate a duplicate (there should now be 11 rows)
- Alternatively, you can recast the same ballot id, but with different selections
3. create castballots.json with some subset (e.g. the first 8)
4. create spoiledballots.json leaving at least one off the list (e.g. add ballot 9.  ballot 10 is in neither list).
5. Tally Votes > Announce > load the ballots, cast & spoiled id's.
6. hit `next` to decrypt
7. expected: correct results show up

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.

💔Thank you!