### PR TITLE
✨ Add Spoiled Ballot Trackers into CSV

### DIFF
--- a/src/electionguard/models/BallotCountStatus.ts
+++ b/src/electionguard/models/BallotCountStatus.ts
@@ -1,0 +1,7 @@
+enum BallotCountStatus {
+  NotCounted = 0,
+  Counted = 1,
+  Spoiled = 2,
+}
+
+export default BallotCountStatus

--- a/src/electionguard/models/BallotStatus.ts
+++ b/src/electionguard/models/BallotStatus.ts
@@ -2,6 +2,7 @@ import { CsvAsJson } from './CsvAsJson'
 
 export interface BallotStatus {
   trackingId: string
+  status: number
   approximateCastTime: string
   location: string
 }

--- a/src/electionguard/utils/csvConverter.ts
+++ b/src/electionguard/utils/csvConverter.ts
@@ -8,6 +8,7 @@ import { BallotStatus, BallotStatusesFile } from '../models/BallotStatus'
 import { ElectionResult, ElectionResultsFile } from '../models/ElectionResult'
 import { Tally, YesNoVoteTally, CandidateVoteTally } from '../models'
 import { Json2CsvOptions } from '../models/CsvAsJson'
+import BallotCountStatus from '../models/BallotCountStatus'
 
 const approximateCastTime = process.env.REACT_APP_POLLING_DATE || '01/01/2020'
 const location = process.env.REACT_APP_POLLING_LOCATION || 'Location'
@@ -19,10 +20,22 @@ const defaultCsvOptions: Json2CsvOptions = {
   header: false,
 }
 
-export const exportTrackerCsv = (trackers: string[]): BallotStatusesFile => {
-  const statuses: BallotStatus[] = trackers.map(
+export const exportTrackerCsv = (
+  castTrackers: string[],
+  spoiledTrackers: string[]
+): BallotStatusesFile => {
+  const castStatuses: BallotStatus[] = castTrackers.map(
     (tracker: string): BallotStatus => ({
       trackingId: tracker,
+      status: BallotCountStatus.Counted,
+      approximateCastTime,
+      location,
+    })
+  )
+  const spoiledStatuses: BallotStatus[] = spoiledTrackers.map(
+    (tracker: string): BallotStatus => ({
+      trackingId: tracker,
+      status: BallotCountStatus.Spoiled,
       approximateCastTime,
       location,
     })
@@ -30,9 +43,9 @@ export const exportTrackerCsv = (trackers: string[]): BallotStatusesFile => {
   return {
     options: {
       ...defaultCsvOptions,
-      fields: ['trackingId', 'approximateCastTime', 'location'],
+      fields: ['trackingId', 'approximateCastTime', 'location', 'status'],
     },
-    data: statuses,
+    data: [...castStatuses, ...spoiledStatuses],
   }
 }
 

--- a/src/pages/Tally/TallyPage.tsx
+++ b/src/pages/Tally/TallyPage.tsx
@@ -243,7 +243,7 @@ const TallyPage = () => {
     UsbContext
   )
 
-  const { castTrackers } = useContext(TallyContext)
+  const { castTrackers, spoiledTrackers } = useContext(TallyContext)
 
   const tallyDisplayRef = useRef(null) // eslint-disable-line
 
@@ -268,7 +268,7 @@ const TallyPage = () => {
       throw new Error('failed to write tallied ballots')
     }
 
-    const trackers = exportTrackerCsv(castTrackers)
+    const trackers = exportTrackerCsv(castTrackers, spoiledTrackers)
     result = await write(adminDriveIndex, trackersFile, trackers)
     if (!result.success) {
       throw new Error('failed to write trackers')


### PR DESCRIPTION
### Issue

Fixes #44 

### Description
Add spoiled ballot trackers to csv. This includes adding the status to match the tracking site to ensure ballot trackers are set as cast or spoiled.

### Testing
This can be tested for real with the usb-module activated OR the mocks can be used and a breakpoint on the trackers.csv

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.